### PR TITLE
Add policy feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.0
+
+Add Policy classes.
+- add policies: `PolicyEntry` as class for all policies in the directory or repository, using `PolicyGroup`, `PolicyResource`, `PolicySubject` for
+a better data encapsulation
+- add `InvalidArgumentException` for arguments which are not matching the expectations
+
 ## 0.1.0
 
 First release of the S3I Flutter package. Currently supported:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,10 +51,12 @@ class MyHomePage extends StatefulWidget {
 
 class _MyHomePageState extends State<MyHomePage> {
   final thingIdInputController = TextEditingController();
+  final policyIdInputController = TextEditingController();
 
   // s3i values
   AccessToken? accessToken;
   Thing? requestedThing;
+  PolicyEntry? requestedPolicy;
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +72,9 @@ class _MyHomePageState extends State<MyHomePage> {
               Divider(height: 5, thickness: 5),
               _buildThingRequestArea(),
               Divider(height: 5, thickness: 5),
-              _buildEditThingArea()
+              _buildEditThingArea(),
+              Divider(height: 5, thickness: 5),
+              _buildPolicyRequestArea()
             ],
           ),
         ));
@@ -135,9 +139,12 @@ class _MyHomePageState extends State<MyHomePage> {
                     } on S3IException catch (e) {
                       debugPrint("Request Thing failed");
                       debugPrint(e.toString());
+                      setState(() {
+                        requestedThing = null;
+                      });
                     }
                   },
-                  child: Text("Request"))
+                  child: Text("Request Thing"))
             ],
           ),
           SizedBox(height: 8),
@@ -170,6 +177,47 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
           )
         : Container();
+  }
+
+  Widget _buildPolicyRequestArea() {
+    return Padding(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: policyIdInputController,
+                ),
+              ),
+              SizedBox(width: 8),
+              OutlinedButton(
+                  onPressed: () async {
+                    try {
+                      // requests the given policy
+                      // you need read access to the policy
+                      var policy = await MyHomePage.s3i
+                          .getPolicy(policyIdInputController.text);
+                      setState(() {
+                        requestedPolicy = policy;
+                      });
+                    } on S3IException catch (e) {
+                      debugPrint("Request Policy failed");
+                      debugPrint(e.toString());
+                      setState(() {
+                        requestedPolicy = null;
+                      });
+                    }
+                  },
+                  child: Text("Request Policy"))
+            ],
+          ),
+          SizedBox(height: 8),
+          if (requestedPolicy != null) Text(requestedPolicy.toString())
+        ],
+      ),
+    );
   }
 
   @override

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -134,7 +134,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.1"
+    version: "0.2.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/s3i_flutter.dart
+++ b/lib/s3i_flutter.dart
@@ -18,6 +18,12 @@ export 'src/exceptions/parse_exception.dart';
 export 'src/exceptions/max_retry_exception.dart';
 export 'src/exceptions/network_response_exception.dart';
 
+//policy
+export 'src/policy/policy_entry.dart';
+export 'src/policy/policy_group.dart';
+export 'src/policy/policy_resource.dart';
+export 'src/policy/policy_subject.dart';
+
 //query
 export 'src/query/query_assembler.dart';
 export 'src/query/field_query.dart';

--- a/lib/src/exceptions/invalid_argument_exception.dart
+++ b/lib/src/exceptions/invalid_argument_exception.dart
@@ -1,0 +1,11 @@
+import 'package:s3i_flutter/src/exceptions/s3i_exception.dart';
+
+/// Exception thrown when an argument is not matching the expectations.
+class InvalidArgumentException extends S3IException {
+  InvalidArgumentException(String message) : super(message);
+
+  @override
+  String toString() {
+    return "InvalidArgumentException: $errorMessage";
+  }
+}

--- a/lib/src/policy/policy_entry.dart
+++ b/lib/src/policy/policy_entry.dart
@@ -1,0 +1,192 @@
+import 'package:s3i_flutter/src/entry.dart';
+import 'package:s3i_flutter/src/exceptions/invalid_argument_exception.dart';
+import 'package:s3i_flutter/src/exceptions/invalid_json_schema_exception.dart';
+import 'package:s3i_flutter/src/exceptions/json_missing_key_exception.dart';
+import 'package:s3i_flutter/src/policy/policy_group.dart';
+import 'package:s3i_flutter/src/policy/policy_resource.dart';
+import 'package:s3i_flutter/src/policy/policy_subject.dart';
+import 'package:s3i_flutter/src/utils/json_key.dart';
+
+/// A specific *Policy* for one [Entry] in the directory or repository.
+///
+/// A policy consists of [PolicyGroup]s and manages the access control to one
+/// specific [Entry] in the S3I-Directory or S3i-Repository.
+/// For more background information see: https://www.eclipse.org/ditto/basic-policy.html
+///
+/// In the S3I-Concept there are two special [PolicyGroup]s which have a specific
+/// meaning:
+/// - owner: An owner has READ and WRITE permission to everything
+/// (thing:/, policy:/, message:/)
+/// - observer: An observer has only READ permission to the thing part (thing:/)
+class PolicyEntry extends Entry {
+  PolicyEntry(String id, {Map<String, PolicyGroup> groups = const {}})
+      : super(id) {
+    _groups = groups;
+  }
+
+  /// The key of the special `owner` group.
+  static const String ownerGroupKey = "owner";
+
+  /// The key of the special `observer` group.
+  static const String observerGroupKey = "observer";
+
+  /// The policy groups of this [PolicyEntry].
+  ///
+  /// The key is the name of the group.
+  late Map<String, PolicyGroup> _groups;
+
+  /// Returns a [PolicyEntry] with groups (subjects and resources) specified
+  /// in the [map].
+  ///
+  /// Throws a [InvalidArgumentException] if the map is empty.
+  /// Throws a [JsonMissingKeyException] if there is no `policyId` key in
+  /// the [map].
+  /// Throws a [InvalidJsonSchemaException] if the `entry` key doesn't contain
+  /// valid [PolicyGroup]s.
+  factory PolicyEntry.fromJson(Map<String, dynamic> map) {
+    if (map.isEmpty) throw InvalidArgumentException('empty map');
+    String pId = map.containsKey(JsonKey.policyId)
+        ? map[JsonKey.policyId]
+        : throw JsonMissingKeyException(JsonKey.policyId, map.toString());
+    PolicyEntry pE = PolicyEntry(pId);
+    try {
+      if (map.containsKey(JsonKey.entries)) {
+        Map<String, dynamic> gro = map[JsonKey.entries];
+        for (var k in gro.keys) {
+          pE._groups[k] = PolicyGroup.fromJson(k, gro[k]);
+        }
+      }
+    } on TypeError catch (e) {
+      throw InvalidJsonSchemaException(e.stackTrace.toString(), map.toString());
+    }
+    return pE;
+  }
+
+  /// Returns the stored information about this [PolicyEntry] in a [Map]
+  /// which could be directly used to creates a json entry.
+  ///
+  /// Stores [id] and [_groups] in the [Map].
+  @override
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> newJson = Map();
+    newJson[JsonKey.policyId] = id;
+    if (_groups.isNotEmpty) {
+      Map<String, dynamic> gro = _groups
+          .map((key, value) => MapEntry<String, dynamic>(key, value.toJson()));
+      newJson[JsonKey.subjects] = gro;
+    }
+    return newJson;
+  }
+
+  @override
+  String toString() {
+    return "PolicyEntry($id: $_groups)";
+  }
+
+  /// Returns the value of [_groups].
+  Map<String, PolicyGroup> getGroups() {
+    return _groups;
+  }
+
+  /// Returns the [PolicyGroup] in [_groups] matching [name].
+  ///
+  /// Throws [InvalidArgumentException] if there is no group with this name.
+  PolicyGroup getGroup(String name) {
+    if (_groups.containsKey(name)) return _groups[name]!;
+    throw InvalidArgumentException("No group [$name] found");
+  }
+
+  /// Adds the given [group] to the [_groups] of this entry.
+  ///
+  /// If [PolicyGroup._name] is already a key in [_groups], the old group
+  /// gets overwritten.
+  void insertGroup(PolicyGroup group) {
+    _groups[group.getName()] = group;
+  }
+
+  /// Removes [name] and its associated [PolicyGroup] from [_groups].
+  ///
+  /// Returns the [PolicyGroup] associated with [name] before it was removed.
+  /// Returns `null` if [name] was not in the map.
+  PolicyGroup? deleteGroup(String name) {
+    return _groups.remove(name);
+  }
+
+  /// Returns a map of [PolicySubject]s who are in the special group `owner`.
+  ///
+  /// Throws [InvalidArgumentException] if there is no `owner` group.
+  Map<String, PolicySubject> getAllOwners() {
+    var owner = getGroup(ownerGroupKey);
+    return owner.subjects;
+  }
+
+  /// Adds the given [owner] to the special group `owner`.
+  ///
+  /// If [PolicySubject._id] is already a member of the group, the old value
+  /// gets overwritten. If there is no `owner` group present, this method
+  /// will create one.
+  void insertOwner(PolicySubject owner) {
+    if (!_groups.containsKey(ownerGroupKey)) {
+      Map<String, PolicyResource> resource = {
+        "thing:/": PolicyResource("thing:/",
+            grant: {PermissionType.read, PermissionType.write}),
+        "policy:/": PolicyResource("policy:/",
+            grant: {PermissionType.read, PermissionType.write}),
+        "message:/": PolicyResource("message:/",
+            grant: {PermissionType.read, PermissionType.write})
+      };
+      //TODO: add s3i admin entry?
+      insertGroup(PolicyGroup(ownerGroupKey,
+          subjects: {owner.getId(): owner}, resources: resource));
+    } else {
+      _groups[ownerGroupKey]!.subjects[owner.getId()] = owner;
+    }
+  }
+
+  /// Removes [name] and its associated [PolicySubject] from the `owner` group.
+  ///
+  /// Returns the [PolicySubject] associated with [name] before it was removed.
+  /// Returns `null` if [name] was no `owner` or there is no `owner` group.
+  PolicySubject? removeOwner(String name) {
+    if (!_groups.containsKey(ownerGroupKey)) return null;
+    var owner = _groups[ownerGroupKey];
+    return owner!.subjects.remove(name);
+  }
+
+  /// Returns a map of [PolicySubject]s who are in the special group `observer`.
+  ///
+  /// Throws [InvalidArgumentException] if there is no `observer` group.
+  Map<String, PolicySubject> getAllObservers() {
+    var observer = getGroup(observerGroupKey);
+    return observer.subjects;
+  }
+
+  /// Adds the given [observer] to the special group `observer`.
+  ///
+  /// If [PolicySubject._id] is already a member of the group, the old value
+  /// gets overwritten. If there is no `observer` group present, this method
+  /// will create one.
+  void insertObserver(PolicySubject observer) {
+    if (!_groups.containsKey(observerGroupKey)) {
+      Map<String, PolicyResource> resource = {
+        "thing:/": PolicyResource("thing:/", grant: {PermissionType.read})
+      };
+      insertGroup(PolicyGroup(observerGroupKey,
+          subjects: {observer.getId(): observer}, resources: resource));
+    } else {
+      _groups[observerGroupKey]!.subjects[observer.getId()] = observer;
+    }
+  }
+
+  /// Removes [name] and its associated [PolicySubject] from
+  /// the `observer` group.
+  ///
+  /// Returns the [PolicySubject] associated with [name] before it was removed.
+  /// Returns `null` if [name] was no `observer` or
+  /// there is no `observer` group.
+  PolicySubject? removeObserver(String name) {
+    if (!_groups.containsKey(observerGroupKey)) return null;
+    var observer = _groups[observerGroupKey];
+    return observer!.subjects.remove(name);
+  }
+}

--- a/lib/src/policy/policy_entry.dart
+++ b/lib/src/policy/policy_entry.dart
@@ -19,16 +19,15 @@ import 'package:s3i_flutter/src/utils/json_key.dart';
 /// (thing:/, policy:/, message:/)
 /// - observer: An observer has only READ permission to the thing part (thing:/)
 class PolicyEntry extends Entry {
-  PolicyEntry(String id, {Map<String, PolicyGroup> groups = const {}})
-      : super(id) {
-    _groups = groups;
+  PolicyEntry(String id, {Map<String, PolicyGroup>? entryGroups}) : super(id) {
+    _groups = {...?entryGroups};
   }
 
   /// The key of the special `owner` group.
-  static const String ownerGroupKey = "owner";
+  static final String ownerGroupKey = "owner";
 
   /// The key of the special `observer` group.
-  static const String observerGroupKey = "observer";
+  static final String observerGroupKey = "observer";
 
   /// The policy groups of this [PolicyEntry].
   ///
@@ -73,7 +72,7 @@ class PolicyEntry extends Entry {
     if (_groups.isNotEmpty) {
       Map<String, dynamic> gro = _groups
           .map((key, value) => MapEntry<String, dynamic>(key, value.toJson()));
-      newJson[JsonKey.subjects] = gro;
+      newJson[JsonKey.entries] = gro;
     }
     return newJson;
   }
@@ -101,7 +100,7 @@ class PolicyEntry extends Entry {
   /// If [PolicyGroup._name] is already a key in [_groups], the old group
   /// gets overwritten.
   void insertGroup(PolicyGroup group) {
-    _groups[group.getName()] = group;
+    _groups[group.name] = group;
   }
 
   /// Removes [name] and its associated [PolicyGroup] from [_groups].
@@ -129,17 +128,17 @@ class PolicyEntry extends Entry {
     if (!_groups.containsKey(ownerGroupKey)) {
       Map<String, PolicyResource> resource = {
         "thing:/": PolicyResource("thing:/",
-            grant: {PermissionType.read, PermissionType.write}),
+            grants: {PermissionType.read, PermissionType.write}),
         "policy:/": PolicyResource("policy:/",
-            grant: {PermissionType.read, PermissionType.write}),
+            grants: {PermissionType.read, PermissionType.write}),
         "message:/": PolicyResource("message:/",
-            grant: {PermissionType.read, PermissionType.write})
+            grants: {PermissionType.read, PermissionType.write})
       };
       //TODO: add s3i admin entry?
       insertGroup(PolicyGroup(ownerGroupKey,
-          subjects: {owner.getId(): owner}, resources: resource));
+          policySubjects: {owner.id: owner}, policyResources: resource));
     } else {
-      _groups[ownerGroupKey]!.subjects[owner.getId()] = owner;
+      _groups[ownerGroupKey]!.subjects[owner.id] = owner;
     }
   }
 
@@ -169,12 +168,12 @@ class PolicyEntry extends Entry {
   void insertObserver(PolicySubject observer) {
     if (!_groups.containsKey(observerGroupKey)) {
       Map<String, PolicyResource> resource = {
-        "thing:/": PolicyResource("thing:/", grant: {PermissionType.read})
+        "thing:/": PolicyResource("thing:/", grants: {PermissionType.read})
       };
       insertGroup(PolicyGroup(observerGroupKey,
-          subjects: {observer.getId(): observer}, resources: resource));
+          policySubjects: {observer.id: observer}, policyResources: resource));
     } else {
-      _groups[observerGroupKey]!.subjects[observer.getId()] = observer;
+      _groups[observerGroupKey]!.subjects[observer.id] = observer;
     }
   }
 

--- a/lib/src/policy/policy_group.dart
+++ b/lib/src/policy/policy_group.dart
@@ -1,0 +1,94 @@
+import 'package:s3i_flutter/src/exceptions/invalid_json_schema_exception.dart';
+import 'package:s3i_flutter/src/json_serializable_object.dart';
+import 'package:s3i_flutter/src/policy/policy_entry.dart';
+import 'package:s3i_flutter/src/policy/policy_resource.dart';
+import 'package:s3i_flutter/src/policy/policy_subject.dart';
+import 'package:s3i_flutter/src/utils/json_key.dart';
+
+/// A specific *Group* in a policy entry.
+///
+/// This ties specific [PolicySubject]s and [PolicyResource]s together.
+/// Default groups in the S3I-Concept are `owner` and `observer`.
+/// See [PolicyEntry] for more information.
+class PolicyGroup implements JsonSerializableObject {
+  PolicyGroup(this._name,
+      {this.subjects = const {}, this.resources = const {}});
+
+  /// The identifier of this [PolicyGroup].
+  ///
+  /// This could be everything but should be self explanatory
+  /// and consider readability.
+  /// Default names in the S3I-Concept are `owner` and `observer`.
+  String _name;
+
+  /// The subjects of this [PolicyGroup].
+  ///
+  /// > Subjects in a policy define who gets permissions granted/revoked
+  /// > on the resources of a policy entry.
+  ///
+  /// The key is the id of the subject.
+  Map<String, PolicySubject> subjects;
+
+  /// The protected resources of this [PolicyGroup].
+  ///
+  /// The key is the path of the resource.
+  Map<String, PolicyResource> resources;
+
+  /// Returns a [PolicyGroup] with the [name] and the [subjects] and [resources]
+  /// specified in the given [json].
+  ///
+  /// Throws a [InvalidJsonSchemaException] if [json] could not be parsed
+  /// to valid [subjects] and [resources].
+  factory PolicyGroup.fromJson(String name, Map<String, dynamic> json) {
+    PolicyGroup pG = PolicyGroup(name);
+    try {
+      if (json.containsKey(JsonKey.subjects)) {
+        Map<String, dynamic> sub = json[JsonKey.subjects];
+        for (var k in sub.keys) {
+          pG.subjects[k] = PolicySubject.fromJson(k, sub[k]);
+        }
+      }
+      if (json.containsKey(JsonKey.resources)) {
+        Map<String, dynamic> res = json[JsonKey.resources];
+        for (var k in res.keys) {
+          pG.resources[k] = PolicyResource.fromJson(k, res[k]);
+        }
+      }
+    } on TypeError catch (e) {
+      throw InvalidJsonSchemaException(
+          e.stackTrace.toString(), json.toString());
+    }
+    return pG;
+  }
+
+  /// Returns the stored information about this [PolicyGroup] in a [Map]
+  /// which could be directly used to creates a json entry.
+  ///
+  /// Stores [subjects] and [resources] in the [Map].
+  /// The [Map] is empty if both [Map]s don't contains entries.
+  @override
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> newJson = Map();
+    if (subjects.isNotEmpty) {
+      Map<String, dynamic> sub = subjects
+          .map((key, value) => MapEntry<String, dynamic>(key, value.toJson()));
+      newJson[JsonKey.subjects] = sub;
+    }
+    if (resources.isNotEmpty) {
+      Map<String, dynamic> res = resources
+          .map((key, value) => MapEntry<String, dynamic>(key, value.toJson()));
+      newJson[JsonKey.resources] = res;
+    }
+    return newJson;
+  }
+
+  @override
+  String toString() {
+    return "PolicyGroup($_name {subjects: $subjects} {resources $resources})";
+  }
+
+  /// Returns the value stored in [_name].
+  String getName() {
+    return _name;
+  }
+}

--- a/lib/src/policy/policy_group.dart
+++ b/lib/src/policy/policy_group.dart
@@ -11,15 +11,19 @@ import 'package:s3i_flutter/src/utils/json_key.dart';
 /// Default groups in the S3I-Concept are `owner` and `observer`.
 /// See [PolicyEntry] for more information.
 class PolicyGroup implements JsonSerializableObject {
-  PolicyGroup(this._name,
-      {this.subjects = const {}, this.resources = const {}});
+  PolicyGroup(this.name,
+      {Map<String, PolicySubject>? policySubjects,
+      Map<String, PolicyResource>? policyResources}) {
+    subjects = {...?policySubjects};
+    resources = {...?policyResources};
+  }
 
   /// The identifier of this [PolicyGroup].
   ///
   /// This could be everything but should be self explanatory
   /// and consider readability.
   /// Default names in the S3I-Concept are `owner` and `observer`.
-  String _name;
+  final String name;
 
   /// The subjects of this [PolicyGroup].
   ///
@@ -27,12 +31,12 @@ class PolicyGroup implements JsonSerializableObject {
   /// > on the resources of a policy entry.
   ///
   /// The key is the id of the subject.
-  Map<String, PolicySubject> subjects;
+  late Map<String, PolicySubject> subjects;
 
   /// The protected resources of this [PolicyGroup].
   ///
   /// The key is the path of the resource.
-  Map<String, PolicyResource> resources;
+  late Map<String, PolicyResource> resources;
 
   /// Returns a [PolicyGroup] with the [name] and the [subjects] and [resources]
   /// specified in the given [json].
@@ -84,11 +88,6 @@ class PolicyGroup implements JsonSerializableObject {
 
   @override
   String toString() {
-    return "PolicyGroup($_name {subjects: $subjects} {resources $resources})";
-  }
-
-  /// Returns the value stored in [_name].
-  String getName() {
-    return _name;
+    return "PolicyGroup($name {subjects: $subjects} {resources $resources})";
   }
 }

--- a/lib/src/policy/policy_resource.dart
+++ b/lib/src/policy/policy_resource.dart
@@ -21,23 +21,27 @@ enum PermissionType { read, write, execute }
 /// For more information see:
 /// https://www.eclipse.org/ditto/basic-policy.html#which-resources-can-be-controlled
 class PolicyResource implements JsonSerializableObject {
-  PolicyResource(this._path, {this.grant = const {}, this.revoke = const {}});
+  PolicyResource(this.path,
+      {Set<PermissionType>? grants, Set<PermissionType>? revokes}) {
+    grant = {...?grants};
+    revoke = {...?revokes};
+  }
 
   /// The path to the resource.
   ///
   /// This could be something general like `policy:/` or a mor specific path
   /// like `thing:/features/featureX/properties/location`.
-  String _path;
+  final String path;
 
   /// The allowed actions on this resource.
   ///
   /// See [PermissionType] for what is supported.
-  Set<PermissionType> grant;
+  late Set<PermissionType> grant;
 
   /// The permitted actions on this resource.
   ///
   /// See [PermissionType] for what is supported.
-  Set<PermissionType> revoke;
+  late Set<PermissionType> revoke;
 
   /// Returns a [PolicyResource] with the [path]
   /// and enriches it with the given information in [json].
@@ -68,21 +72,14 @@ class PolicyResource implements JsonSerializableObject {
   @override
   Map<String, dynamic> toJson() {
     Map<String, dynamic> newJson = Map();
-    if (grant.isNotEmpty)
       newJson[JsonKey.grant] = _createPermissionString(grant);
-    if (revoke.isNotEmpty)
       newJson[JsonKey.revoke] = _createPermissionString(revoke);
     return newJson;
   }
 
   @override
   String toString() {
-    return "PolicyResource($_path [grant: $grant] [revoke: $revoke])";
-  }
-
-  /// Returns the value stored in [_path].
-  String getPath() {
-    return _path;
+    return "PolicyResource($path [grant: $grant] [revoke: $revoke])";
   }
 
   static Set<PermissionType> _createPermissionSet(List<dynamic> jsonList) {

--- a/lib/src/policy/policy_resource.dart
+++ b/lib/src/policy/policy_resource.dart
@@ -1,0 +1,122 @@
+import 'package:s3i_flutter/src/exceptions/invalid_json_schema_exception.dart';
+import 'package:s3i_flutter/src/json_serializable_object.dart';
+import 'package:s3i_flutter/src/policy/policy_subject.dart';
+import 'package:s3i_flutter/src/utils/json_key.dart';
+
+/// The type of a granted/revoked permission.
+///
+/// Currently supported:
+/// - [PermissionType.read]
+/// - [PermissionType.write]
+/// - [PermissionType.execute]
+///
+/// For further information see:
+/// https://www.eclipse.org/ditto/basic-policy.html#grant-and-revoke-some-permission
+enum PermissionType { read, write, execute }
+
+/// The protected *Resource* of a ditto policy group.
+///
+/// This defines to which part of a ditto entry the corresponding [PolicySubject]
+/// has which permissions granted/revoked.
+/// For more information see:
+/// https://www.eclipse.org/ditto/basic-policy.html#which-resources-can-be-controlled
+class PolicyResource implements JsonSerializableObject {
+  PolicyResource(this._path, {this.grant = const {}, this.revoke = const {}});
+
+  /// The path to the resource.
+  ///
+  /// This could be something general like `policy:/` or a mor specific path
+  /// like `thing:/features/featureX/properties/location`.
+  String _path;
+
+  /// The allowed actions on this resource.
+  ///
+  /// See [PermissionType] for what is supported.
+  Set<PermissionType> grant;
+
+  /// The permitted actions on this resource.
+  ///
+  /// See [PermissionType] for what is supported.
+  Set<PermissionType> revoke;
+
+  /// Returns a [PolicyResource] with the [path]
+  /// and enriches it with the given information in [json].
+  ///
+  /// Throws an [InvalidJsonSchemaException] if [json] could not be parsed to
+  /// valid [grant] and [revoke] parameters.
+  factory PolicyResource.fromJson(String path, Map<String, dynamic> json) {
+    PolicyResource pR = PolicyResource(path);
+    try {
+      if (json.containsKey(JsonKey.grant)) {
+        pR.grant = _createPermissionSet(json[JsonKey.grant]);
+      }
+      if (json.containsKey(JsonKey.revoke)) {
+        pR.revoke = _createPermissionSet(json[JsonKey.revoke]);
+      }
+    } on TypeError catch (e) {
+      throw InvalidJsonSchemaException(
+          e.stackTrace.toString(), json.toString());
+    }
+    return pR;
+  }
+
+  /// Returns the stored information about this [PolicyResource] in a [Map]
+  /// which could be directly used to creates a json entry.
+  ///
+  /// Stores [grant] and [revoke] in the [Map].
+  /// The [Map] is empty if both [Set]s don't contains entries.
+  @override
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> newJson = Map();
+    if (grant.isNotEmpty)
+      newJson[JsonKey.grant] = _createPermissionString(grant);
+    if (revoke.isNotEmpty)
+      newJson[JsonKey.revoke] = _createPermissionString(revoke);
+    return newJson;
+  }
+
+  @override
+  String toString() {
+    return "PolicyResource($_path [grant: $grant] [revoke: $revoke])";
+  }
+
+  /// Returns the value stored in [_path].
+  String getPath() {
+    return _path;
+  }
+
+  static Set<PermissionType> _createPermissionSet(List<dynamic> jsonList) {
+    return jsonList.map((permT) => _permissionTypeFromString(permT)).toSet();
+  }
+
+  static List<String> _createPermissionString(
+      Set<PermissionType> permissionSet) {
+    return permissionSet
+        .map((permT) => _permissionTypeToString(permT))
+        .toList();
+  }
+
+  static PermissionType _permissionTypeFromString(String jsonField) {
+    switch (jsonField) {
+      case "READ":
+        return PermissionType.read;
+      case "WRITE":
+        return PermissionType.write;
+      case "EXECUTE":
+        return PermissionType.execute;
+      default:
+        throw TypeError();
+    }
+  }
+
+  static String _permissionTypeToString(PermissionType permissionType) {
+    switch (permissionType) {
+      case PermissionType.read:
+        return "READ";
+      case PermissionType.write:
+        return "WRITE";
+      case PermissionType.execute:
+        return "EXECUTE";
+    }
+  }
+}

--- a/lib/src/policy/policy_subject.dart
+++ b/lib/src/policy/policy_subject.dart
@@ -1,0 +1,80 @@
+import 'package:s3i_flutter/src/exceptions/invalid_json_schema_exception.dart';
+import 'package:s3i_flutter/src/json_serializable_object.dart';
+import 'package:s3i_flutter/src/utils/json_key.dart';
+
+/// The *Subject* of a ditto policy group.
+///
+/// From https://www.eclipse.org/ditto/basic-policy.html#subjects:
+/// > Subjects in a policy define who gets permissions granted/revoked
+/// > on the resources of a policy entry. Each subject ID contains a prefix
+/// > defining the subject “issuer” (so which party issued the authentication)
+/// > and an actual subject, separated with a colon.
+class PolicySubject implements JsonSerializableObject {
+  PolicySubject(this._id, {this.expiringTimestamp, this.type});
+
+  ///  The subject-id (WHO gets the permissions granted/revoked).
+  ///
+  ///  This could be:
+  ///  - a s3i-identifier
+  ///  - a s3i-idp-group name
+  ///  - a specific user id
+  ///
+  /// Use "nginx:<ID>" as pattern.
+  String _id;
+
+  /// The optional validation date of this subject.
+  ///
+  /// Converts to/from an ISO-8601 string for/from ditto.
+  /// For more information see https://www.eclipse.org/ditto/basic-policy.html#expiring-policy-subjects.
+  DateTime? expiringTimestamp;
+
+  /// An optional description of the subject.
+  String? type;
+
+  /// Returns a [PolicySubject] with the [id]
+  /// and enriches it with the given information in [json].
+  ///
+  /// Throws an [InvalidJsonSchemaException] if [json] contains an "expiry" key
+  /// which could not be parsed by [DateTime.parse()] OR if [json] contains
+  /// an "type" key which isn't a [String].
+  factory PolicySubject.fromJson(String id, Map<String, dynamic> json) {
+    PolicySubject pS = PolicySubject(id);
+    try {
+      if (json.containsKey(JsonKey.expiry)) {
+        pS.expiringTimestamp = DateTime.parse(json[JsonKey.expiry]);
+      }
+      pS.type = json.containsKey(JsonKey.type) ? json[JsonKey.type] : null;
+    } on FormatException catch (e) {
+      //datetime parsing failed
+      throw InvalidJsonSchemaException(e.message, json.toString());
+    } on TypeError catch (e) {
+      throw InvalidJsonSchemaException(
+          e.stackTrace.toString(), json.toString());
+    }
+    return pS;
+  }
+
+  /// Returns the stored information about this [PolicySubject] in a [Map]
+  /// which could be directly used to creates a json entry.
+  ///
+  /// Stores [expiringTimestamp] and [type] in the [Map].
+  /// The [Map] is empty if both fields are [null].
+  @override
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> newJson = Map();
+    if (expiringTimestamp != null)
+      newJson[JsonKey.expiry] = expiringTimestamp!.toIso8601String();
+    if (type != null) newJson[JsonKey.type] = type;
+    return newJson;
+  }
+
+  @override
+  String toString() {
+    return "PolicySubject($_id:[$expiringTimestamp | $type])";
+  }
+
+  /// Returns the value of [_id].
+  String getId() {
+    return _id;
+  }
+}

--- a/lib/src/policy/policy_subject.dart
+++ b/lib/src/policy/policy_subject.dart
@@ -10,7 +10,7 @@ import 'package:s3i_flutter/src/utils/json_key.dart';
 /// > defining the subject “issuer” (so which party issued the authentication)
 /// > and an actual subject, separated with a colon.
 class PolicySubject implements JsonSerializableObject {
-  PolicySubject(this._id, {this.expiringTimestamp, this.type});
+  PolicySubject(this.id, {this.expiringTimestamp, this.type});
 
   ///  The subject-id (WHO gets the permissions granted/revoked).
   ///
@@ -20,7 +20,7 @@ class PolicySubject implements JsonSerializableObject {
   ///  - a specific user id
   ///
   /// Use "nginx:<ID>" as pattern.
-  String _id;
+  final String id;
 
   /// The optional validation date of this subject.
   ///
@@ -43,7 +43,7 @@ class PolicySubject implements JsonSerializableObject {
       if (json.containsKey(JsonKey.expiry)) {
         pS.expiringTimestamp = DateTime.parse(json[JsonKey.expiry]);
       }
-      pS.type = json.containsKey(JsonKey.type) ? json[JsonKey.type] : null;
+      pS.type = json[JsonKey.type];
     } on FormatException catch (e) {
       //datetime parsing failed
       throw InvalidJsonSchemaException(e.message, json.toString());
@@ -70,11 +70,6 @@ class PolicySubject implements JsonSerializableObject {
 
   @override
   String toString() {
-    return "PolicySubject($_id:[$expiringTimestamp | $type])";
-  }
-
-  /// Returns the value of [_id].
-  String getId() {
-    return _id;
+    return "PolicySubject($id:[$expiringTimestamp | $type])";
   }
 }

--- a/lib/src/s3i_core.dart
+++ b/lib/src/s3i_core.dart
@@ -77,4 +77,18 @@ class S3ICore {
       throw NetworkResponseException(response);
     }
   }
+
+  Future<PolicyEntry> getPolicy(String policyId) async {
+    var response = await getDirectory("/policies/" + policyId);
+    if (response.statusCode != 200) throw NetworkResponseException(response);
+    return PolicyEntry.fromJson(jsonDecode(response.body));
+  }
+
+  Future<void> putPolicy(PolicyEntry policy) async {
+    var response =
+        await putDirectory("/policies/" + policy.id, jsonBody: policy.toJson());
+    if (response.statusCode != 204 && response.statusCode != 201) {
+      throw NetworkResponseException(response);
+    }
+  }
 }

--- a/lib/src/utils/json_key.dart
+++ b/lib/src/utils/json_key.dart
@@ -6,6 +6,13 @@ class JsonKey {
   static const String attributes = "attributes";
   static const String items = "items";
   static const String cursor = "cursor";
+  static const String type = "type";
+  static const String expiry = "expiry";
+  static const String grant = "grant";
+  static const String revoke = "revoke";
+  static const String subjects = "subjects";
+  static const String resources = "resources";
+  static const String entries = "entries";
 
 // keycloak
   static const String grantType = "grant_type";

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: s3i_flutter
 description: A library that makes it easy to communicate with the S³I (Smart Systems Service Infrastructure of the KWH4.0).
-version: 0.1.0
+version: 0.2.0
 homepage: https://github.com/LukasPoque/s3i_flutter
 
 environment:

--- a/test/s3i_flutter_test.dart
+++ b/test/s3i_flutter_test.dart
@@ -1,4 +1,5 @@
 import 'unit_tests/directory_thing_test.dart';
+import 'unit_tests/policy_test.dart';
 import 'unit_tests/query_test.dart';
 import 'unit_tests/token_test.dart';
 
@@ -6,4 +7,5 @@ void main() {
   mainThingTests();
   mainQueryTest();
   mainTokenTest();
+  mainPolicyTest();
 }

--- a/test/unit_tests/policy_test.dart
+++ b/test/unit_tests/policy_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:s3i_flutter/s3i_flutter.dart';
+
+void mainPolicyTest() {
+  final Map<String, dynamic> policyJson = {
+    "policyId": "s3i:5812a618-b0ec-46e6-bee5-36745656913e",
+    "entries": {
+      "owner": {
+        "subjects": {
+          "nginx:8c143429-4b27-430f-9c53-409477ae4079": {
+            "type": "nginx basic auth user X"
+          },
+          "nginx:ditto": {"type": "nginx basic auth user"}
+        },
+        "resources": {
+          "policy:/": {
+            "grant": ["READ", "WRITE"],
+            "revoke": []
+          },
+          "thing:/": {
+            "grant": ["READ", "WRITE"],
+            "revoke": []
+          },
+          "message:/": {
+            "grant": ["READ", "WRITE"],
+            "revoke": ["EXECUTE"]
+          }
+        }
+      },
+      "observer": {
+        "subjects": {
+          "nginx:/iWald": {"type": "iWald user group"},
+          "nginx:49332cdc-3a60-420f-8d39-e60d1fabc3a6": {
+            "type": "XXX - Der Forstberater",
+            "expiry": "2021-09-07T14:50:00.000Z"
+          },
+          "nginx:42723e9d-4db4-4f1b-b7cb-28bc62b38cbc": {
+            "type": "Forstliche Dienstleistungen XXX"
+          },
+          "nginx:c38a47b6-7d0e-4c9f-8769-47fc9613730c": {
+            "type": "description X"
+          }
+        },
+        "resources": {
+          "thing:/": {
+            "grant": ["READ"],
+            "revoke": []
+          }
+        }
+      }
+    }
+  };
+
+  test('Load default policy', () {
+    PolicyEntry p = PolicyEntry.fromJson(policyJson);
+    expect(p.getAllOwners().length, 2);
+    expect(p.getAllObservers().length, 4);
+  });
+
+  test('Decode/Encode valid default policy', () {
+    PolicyEntry p = PolicyEntry.fromJson(policyJson);
+    var newJsonMap = p.toJson();
+    expect(newJsonMap, policyJson);
+  });
+
+  test('Check expiry timestamp in default policy', () {
+    PolicyEntry p = PolicyEntry.fromJson(policyJson);
+    PolicySubject policySubject =
+        p.getAllObservers()["nginx:49332cdc-3a60-420f-8d39-e60d1fabc3a6"]!;
+    expect(
+        policySubject.expiringTimestamp
+            ?.isAtSameMomentAs(DateTime.parse("2021-09-07T15:50+01:00")),
+        true);
+  });
+}
+
+void main() {
+  mainPolicyTest();
+}

--- a/test/unit_tests/policy_test.dart
+++ b/test/unit_tests/policy_test.dart
@@ -51,9 +51,12 @@ void mainPolicyTest() {
     }
   };
 
-  test('Load default policy', () {
+  test('Load default policy + manipulate observer', () {
     PolicyEntry p = PolicyEntry.fromJson(policyJson);
-    expect(p.getAllOwners().length, 2);
+    expect(p.getAllObservers().length, 4);
+    p.insertObserver(PolicySubject("nginx:test_observer"));
+    expect(p.getAllObservers().length, 5);
+    p.removeObserver("nginx:/iWald");
     expect(p.getAllObservers().length, 4);
   });
 


### PR DESCRIPTION
Policies are an important mechanism to control who has access to which part of data. Since the S3I supports policies in the directory and repository via ditto policies, this PR adds some basic functionality to the S3I Flutter package.

It enables the user to:
- pull a specific policy from the directory (but the data structure is the same for the repository)
- request and manipulate parts of the policy entry
- update a specific policy in the directory